### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # PlugRequireHeader
 
 [![Build Status](https://travis-ci.org/DevL/plug_require_header.svg?branch=master)](https://travis-ci.org/DevL/plug_require_header)
+[![Deps Status](https://beta.hexfaktor.org/badge/all/github/DevL/plug_require_header.svg)](https://beta.hexfaktor.org/github/DevL/plug_require_header)
 [![Inline docs](http://inch-ci.org/github/DevL/plug_require_header.svg?branch=master)](http://inch-ci.org/github/DevL/plug_require_header)
 [![Hex.pm](https://img.shields.io/hexpm/v/plug_require_header.svg)](https://hex.pm/packages/plug_require_header)
 [![Documentation](https://img.shields.io/badge/Documentation-online-c800c8.svg)](http://hexdocs.pm/plug_require_header)


### PR DESCRIPTION
Hi Lennart,

I wanted to ... I don't know ... leverage the fact that we drank at a rooftop Berlin party together to pitch you my latest Elixir related endavour ... I guess?

Anyhow, here comes the pitch:

[![Deps Status](https://beta.hexfaktor.org/badge/all/github/DevL/plug_require_header.svg)](https://beta.hexfaktor.org/github/DevL/plug_require_header) [![Inline docs](http://inch-ci.org/github/DevL/plug_require_header.svg?branch=master)](http://inch-ci.org/github/DevL/plug_require_header)

You already know the Inch badge on the right: It shows you an analysis for your Elixir project's docs. The new badge does the same thing for your dependencies.

Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released.

This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. I really believe that we can create a great service for the community with this. That said, don't feel any obligation to accept the PR. Just tell me what you think about this idea!
